### PR TITLE
Fixed //mixpanel.com/somefile.js being replaced.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (options) {
 		contents = file.contents.toString().replace(reg, function(content, filePath){
 			var relative;
 
-			if(/^\//.test(filePath)){
+			if(/^\/^\//.test(filePath)){
 				relative = filePath.replace(/^\//, '');
 			}else{
 				if(mainPath.indexOf(assetAbsolute) !== -1){


### PR DESCRIPTION
Hi, I noticed that this plugin breaks when you have urls like `<script async src='//www.google-analytics.com/analytics.js'></script>`. It mistakenly sees that as a relative path. I have fixed this in the pull request.

Thanks!
Shawn
