### PR TITLE
Fixed //mixpanel.com/somefile.js being replaced.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (options) {
 		contents = file.contents.toString().replace(reg, function(content, filePath){
 			var relative;
 
-			if(/^\//.test(filePath)){
+			if(/^\/^\//.test(filePath)){
 				relative = filePath.replace(/^\//, '');
 			}else{
 				if(mainPath.indexOf(assetAbsolute) !== -1){

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (options) {
 		contents = file.contents.toString().replace(reg, function(content, filePath){
 			var relative;
 
-			if(/^\/^\//.test(filePath)){
+			if(/^\/[^\/]/.test(filePath)){
 				relative = filePath.replace(/^\//, '');
 			}else{
 				if(mainPath.indexOf(assetAbsolute) !== -1){


### PR DESCRIPTION
Currently it doesn't work for this code: `<script async src='//www.google-analytics.com/analytics.js'></script>`. It tries to replace the CDN because it is only checking for / in urls, not //. This pull request fixes it.

Thanks!
Shawn
